### PR TITLE
Added -ErrorAction Stop to correctly detect failed attempts

### DIFF
--- a/Dell/Install-DellBiosProvider.ps1
+++ b/Dell/Install-DellBiosProvider.ps1
@@ -1,7 +1,7 @@
 <#
     .DESCRIPTION
         Import the Dell Command | PowerShell Provider module
-    
+
     .PARAMETER ModulePath
         Specify the location of the DellBIOSProvider module source files. This parameter should be specified when the script is running in WinPE or when the system does not have internet access
 
@@ -9,7 +9,7 @@
         Specify the location of the .dll files required to run the DellBIOSProvider module. This parameter should be specified when the script is running in WinPE or when the system does not have the required Visual C++ Redistributables installed
 
     .EXAMPLE
-        Running in a full Windows OS and installing from the internet    
+        Running in a full Windows OS and installing from the internet
             Install-DellBiosProvider.ps1
 
         Running in WinPE
@@ -33,7 +33,7 @@ param(
         {
             throw "The ModulePath argument must be a folder path"
         }
-        return $true 
+        return $true
     })]
     [Parameter(Mandatory=$false)][System.IO.DirectoryInfo]$ModulePath,
     [ValidateScript({
@@ -45,7 +45,7 @@ param(
         {
             throw "The DllPath argument must be a folder path"
         }
-        return $true 
+        return $true
     })]
     [Parameter(Mandatory=$false)][System.IO.DirectoryInfo]$DllPath
 )
@@ -88,7 +88,7 @@ Function Get-TaskSequenceStatus
 Function Uninstall-DellBIOSProvider
 {
     Write-LogEntry -Value "Uninstall previous versions of the DellBIOSProvider module" -Severity 1
-    $Module = Get-Package DellBIOSProvider -ErrorAction SilentlyContinue
+    $Module = Get-Module -ListAvailable -Name 'DellBIOSProvider' -ErrorAction SilentlyContinue
     $ModuleFile = Test-Path "$ModuleInstallPath\WindowsPowerShell\Modules\DellBIOSProvider"
 
     if (($NULL -eq $Module) -and !($ModuleFile))
@@ -101,7 +101,7 @@ Function Uninstall-DellBIOSProvider
         {
             while ($NULL -ne $Module)
             {
-                $Version = Get-Package DellBIOSProvider -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Version
+                $Version = Get-Module -ListAvailable -Name 'DellBIOSProvider' -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Version
                 Write-LogEntry -Value "Uninstalling DellBIOSProvider module version $Version" -Severity 1
                 $Error.Clear()
                 try
@@ -117,14 +117,14 @@ Function Uninstall-DellBIOSProvider
                     Write-LogEntry -Value "Successfully uninstalled DellBIOSProvider module version $Version" -Severity 1
                 }
                 Clear-Variable Module,Version
-                $Module = Get-Package DellBIOSProvider -ErrorAction SilentlyContinue
+                $Module = Get-Module -ListAvailable -Name 'DellBIOSProvider' -ErrorAction SilentlyContinue
             }
         }
         else
         {
             Remove-Item "$ModuleInstallPath\WindowsPowerShell\Modules\DellBIOSProvider" -Recurse -Force
             Write-LogEntry -Value "Successfully uninstalled the existing DellBIOSProvider module" -Severity 1
-        }   
+        }
     }
 }
 
@@ -261,7 +261,7 @@ Function Copy-Dll
             {
                 throw "The specified file must be a .dll file"
             }
-            return $true 
+            return $true
         })]
         [Parameter(Mandatory=$true)][System.IO.FileInfo]$DllFile,
         [ValidateScript({
@@ -273,7 +273,7 @@ Function Copy-Dll
             {
                 throw "The DllTargetPath argument must be a folder path"
             }
-            return $true 
+            return $true
         })]
         [Parameter(Mandatory=$true)][System.IO.DirectoryInfo]$DllTargetPath,
         [ValidateScript({
@@ -285,7 +285,7 @@ Function Copy-Dll
             {
                 throw "The DllSourcePath argument must be a folder path"
             }
-            return $true 
+            return $true
         })]
         [Parameter(Mandatory=$false)][System.IO.DirectoryInfo]$DllSourcePath
     )
@@ -294,7 +294,7 @@ Function Copy-Dll
     {
         Write-LogEntry -Value "Could not find $DllTargetPath\$DllFile" -Severity 2
         Write-LogEntry -Value "Copying $DllFile to $DllTargetPath" -Severity 1
-        
+
         if ($DllSourcePath)
         {
             $Error.Clear()
@@ -332,7 +332,7 @@ Function Copy-Dll
     }
     else
     {
-        Write-LogEntry -Value "Found $DllFile" -Severity 1    
+        Write-LogEntry -Value "Found $DllFile" -Severity 1
     }
 }
 #Write data to a CMTrace compatible log file. (Credit to SCConfigMgr - https://www.scconfigmgr.com/)
@@ -352,7 +352,7 @@ Function Write-LogEntry
 	)
     # Determine log file location
     $LogFilePath = Join-Path -Path $LogsDirectory -ChildPath $FileName
-		
+
     # Construct time stamp for log entry
     if (-not(Test-Path -Path 'variable:global:TimezoneBias'))
     {
@@ -367,16 +367,16 @@ Function Write-LogEntry
         }
     }
     $Time = -join @((Get-Date -Format "HH:mm:ss.fff"), $TimezoneBias)
-		
+
     # Construct date for log entry
     $Date = (Get-Date -Format "MM-dd-yyyy")
-		
+
     # Construct context for log entry
     $Context = $([System.Security.Principal.WindowsIdentity]::GetCurrent().Name)
-		
+
     # Construct final log entry
     $LogText = "<![LOG[$($Value)]LOG]!><time=""$($Time)"" date=""$($Date)"" component=""Install-DellBiosProvider"" context=""$($Context)"" type=""$($Severity)"" thread=""$($PID)"" file="""">"
-		
+
     # Add value to log file
     try
     {
@@ -419,7 +419,7 @@ else
 {
     $ErrMsg = "The current PowerShell version is $PsVer. The mininum supported PowerShell version is 3"
     Write-LogEntry -Value $ErrMsg -Severity 3
-    throw $ErrMsg  
+    throw $ErrMsg
 }
 
 #Check the SMBIOS version
@@ -472,14 +472,14 @@ if ([System.Environment]::Is64BitOperatingSystem)
 }
 else
 {
-    $ModuleInstallPath = ${env:ProgramFiles(x86)}    
+    $ModuleInstallPath = ${env:ProgramFiles(x86)}
 }
 
 #Get the version of the currently installed DellBIOSProvider module
 Write-LogEntry -Value "Checking the version of the currently installed DellBIOSProvider module" -Severity 1
 try
 {
-    $LocalVersion = Get-Package DellBIOSProvider -ErrorAction Stop | Select-Object -ExpandProperty Version
+    $LocalVersion = Get-Module -ListAvailable -Name 'DellBIOSProvider' -ErrorAction Stop | Select-Object -ExpandProperty Version
 }
 catch
 {
@@ -613,7 +613,7 @@ else
     {
         Import-Module DellBIOSProvider -Force -ErrorAction Stop
     }
-    catch 
+    catch
     {
         Write-LogEntry -Value "Failed to import the DellBIOSProvider module" -Severity 3
         throw "Failed to import the DellBIOSProvider module"

--- a/Dell/Install-DellBiosProvider.ps1
+++ b/Dell/Install-DellBiosProvider.ps1
@@ -68,7 +68,7 @@ param(
     })]
     [Parameter(Mandatory=$false)][System.IO.DirectoryInfo]$LogsDirectory = "$ENV:ProgramData\BiosScripts\Dell",
     [ValidateScript({
-        if ($_ -notmatch "(\.log")
+        if ($_ -notmatch "\.log")
         {
             throw "The LogFilename must end with .log"
         }

--- a/Dell/Manage-DellBiosPasswords.ps1
+++ b/Dell/Manage-DellBiosPasswords.ps1
@@ -25,7 +25,7 @@
 
 	.PARAMETER OldSystemPassword
 		Specify the old system password(s) to be changed. Multiple passwords can be specified as a comma seperated list.
-	
+
 	.PARAMETER NoUserPrompt
 		The script will run silently and will not prompt the user with a message box.
 
@@ -38,7 +38,7 @@
 	.EXAMPLE
 		Set a new admin password
 		Manage-DellBiosPasswords.ps1 -AdminSet -AdminPassword <String>
-	
+
 		Set or change a admin password
 		Manage-DellBiosPasswords.ps1 -AdminSet -AdminPassword <String> -OldAdminPassword <String1>,<String2>,<String3>
 
@@ -116,7 +116,7 @@ Function Start-UserPrompt
         [Parameter(Mandatory=$True)][ValidateNotNullOrEmpty()][String[]]$BodyText,
         [Parameter(Mandatory=$True)][ValidateNotNullOrEmpty()][String[]]$TitleText
     )
-	
+
     if (!($NoUserPrompt))
 	{
 		(New-Object -ComObject Wscript.Shell).Popup("$BodyText",0,"$TitleText",0x0 + 0x30) | Out-Null
@@ -140,7 +140,7 @@ Function Write-LogEntry
 	)
 	# Determine log file location
 	$LogFilePath = Join-Path -Path $LogsDirectory -ChildPath $FileName
-		
+
 	# Construct time stamp for log entry
 	if (-not(Test-Path -Path 'variable:global:TimezoneBias'))
 	{
@@ -155,16 +155,16 @@ Function Write-LogEntry
 		}
 	}
 	$Time = -join @((Get-Date -Format "HH:mm:ss.fff"), $TimezoneBias)
-		
+
 	# Construct date for log entry
 	$Date = (Get-Date -Format "MM-dd-yyyy")
-		
+
 	# Construct context for log entry
 	$Context = $([System.Security.Principal.WindowsIdentity]::GetCurrent().Name)
-		
+
 	# Construct final log entry
 	$LogText = "<![LOG[$($Value)]LOG]!><time=""$($Time)"" date=""$($Date)"" component=""Manage-DellBiosPasswords"" context=""$($Context)"" type=""$($Severity)"" thread=""$($PID)"" file="""">"
-		
+
 	# Add value to log file
 	try
 	{
@@ -202,14 +202,14 @@ if ([System.Environment]::Is64BitOperatingSystem)
 }
 else
 {
-    $ModuleInstallPath = ${env:ProgramFiles(x86)}    
+    $ModuleInstallPath = ${env:ProgramFiles(x86)}
 }
 
 #Verify the DellBIOSProvider module is installed
 Write-LogEntry -Value "Checking the version of the currently installed DellBIOSProvider module" -Severity 1
 try
 {
-    $LocalVersion = Get-Package DellBIOSProvider -ErrorAction Stop | Select-Object -ExpandProperty Version
+	$LocalVersion = Get-Module -ListAvailable -Name 'DellBIOSProvider' -ErrorAction Stop | Select-Object -ExpandProperty Version
 }
 catch
 {
@@ -254,7 +254,7 @@ else
     {
         Import-Module DellBIOSProvider -Force -ErrorAction Stop
     }
-    catch 
+    catch
     {
         Write-LogEntry -Value "Failed to import the DellBIOSProvider module" -Severity 3
         throw "Failed to import the DellBIOSProvider module"
@@ -430,7 +430,7 @@ if ($AdminPasswordCheck -eq "False")
 			if (!($Error))
 			{
 				Write-LogEntry -Value "The admin password has been successfully set" -Severity 1
-			}	
+			}
 		}
 	}
 }
@@ -477,7 +477,7 @@ if ($SystemPasswordCheck -eq "False")
 			if (!($Error))
 			{
 				Write-LogEntry -Value "The system password has been successfully set" -Severity 1
-			}	
+			}
 		}
 	}
 }
@@ -494,7 +494,7 @@ if ($AdminPasswordCheck -eq "True")
 		{
 			$TSEnv.Value("DellSetAdmin") = "Failed"
 		}
-        
+
 		try
 		{
 			Set-Item -Path DellSmbios:\Security\AdminPassword $AdminPassword -Password $AdminPassword -ErrorAction Stop
@@ -542,7 +542,7 @@ if ($AdminPasswordCheck -eq "True")
 			Write-LogEntry -Value "The admin password is already set correctly" -Severity 1
 		}
 	}
-	
+
 	#Clear the existing admin password
 	if (($AdminClear) -and ($DellClearAdmin -ne "Success"))
 	{
@@ -552,7 +552,7 @@ if ($AdminPasswordCheck -eq "True")
 		{
 			$TSEnv.Value("DellClearAdmin") = "Failed"
 		}
-		
+
 		$Counter = 0
 		While($Counter -lt $OldAdminPassword.Count){
 			$Error.Clear()
@@ -576,12 +576,12 @@ if ($AdminPasswordCheck -eq "True")
 				if ($SystemPasswordCheck -eq "True")
 				{
 					Write-LogEntry -Value "The admin password and system password have been successfully cleared" -Severity 1
-					break	
+					break
 				}
 				else
 				{
 					Write-LogEntry -Value "The admin password has been successfully cleared" -Severity 1
-					break	
+					break
 				}
 			}
 			if ($AdminPWClear -eq "Failed")
@@ -604,7 +604,7 @@ if ($SystemPasswordCheck -eq "True")
 		{
 			$TSEnv.Value("DellSetSystem") = "Failed"
 		}
-        
+
 		try
 		{
 			Set-Item -Path DellSmbios:\Security\SystemPassword $SystemPassword -Password $SystemPassword -ErrorAction Stop
@@ -652,7 +652,7 @@ if ($SystemPasswordCheck -eq "True")
 			Write-LogEntry -Value "The system password is already set correctly" -Severity 1
 		}
 	}
-	
+
 	#Clear the existing system password
 	if (($SystemClear) -and ($DellClearSystem -ne "Success"))
 	{

--- a/Dell/Manage-DellBiosPasswords.ps1
+++ b/Dell/Manage-DellBiosPasswords.ps1
@@ -35,6 +35,10 @@
 	.PARAMETER SMSTSPasswordRetry
 		For use in a task sequence. If specified, the script will assume the script needs to run at least one more time. This will ignore password errors and suppress user prompts.
 
+	.PARAMETER LogsDirectory
+        The path of the directory where log files will be written to
+        If in a task sequence, LogsDirectory will automatically change to _SMSTSLogPath
+
 	.EXAMPLE
 		Set a new admin password
 		Manage-DellBiosPasswords.ps1 -AdminSet -AdminPassword <String>
@@ -71,7 +75,8 @@ param(
 	[Parameter(Mandatory=$false)][ValidateNotNullOrEmpty()][String[]]$OldSystemPassword,
 	[Parameter(Mandatory=$false)][Switch]$NoUserPrompt,
 	[Parameter(Mandatory=$false)][Switch]$ContinueOnError,
-	[Parameter(Mandatory=$false)][Switch]$SMSTSPasswordRetry
+	[Parameter(Mandatory=$false)][Switch]$SMSTSPasswordRetry,
+	[Parameter(Mandatory=$false)][System.IO.DirectoryInfo]$LogsDirectory = "$ENV:ProgramData\BiosScripts\Dell"
 )
 
 #Functions ====================================================================================================================
@@ -186,11 +191,10 @@ if (Get-TaskSequenceStatus)
 }
 else
 {
-	$LogsDirectory = "$ENV:ProgramData\BiosScripts\Dell"
-	if (!(Test-Path -PathType Container $LogsDirectory))
-	{
-		New-Item -Path $LogsDirectory -ItemType "Directory" -Force | Out-Null
-	}
+    if (!(Test-Path -PathType Container $LogsDirectory))
+    {
+        New-Item -Path $LogsDirectory -ItemType "Directory" -Force | Out-Null
+    }
 }
 Write-Output "Log path set to $LogsDirectory\Manage-DellBiosPasswords.log"
 Write-LogEntry -Value "START - Dell BIOS password management script" -Severity 1

--- a/Dell/Manage-DellBiosPasswords.ps1
+++ b/Dell/Manage-DellBiosPasswords.ps1
@@ -92,7 +92,7 @@ param(
     })]
 	[Parameter(Mandatory=$false)][System.IO.DirectoryInfo]$LogsDirectory = "$ENV:ProgramData\BiosScripts\Dell",
 	[ValidateScript({
-        if ($_ -notmatch "(\.log")
+        if ($_ -notmatch "\.log")
         {
             throw "The LogFilename must end with .log"
         }

--- a/Dell/Manage-DellBiosSettings.ps1
+++ b/Dell/Manage-DellBiosSettings.ps1
@@ -1,7 +1,7 @@
 <#
     .DESCRIPTION
         Automatically configure Dell BIOS settings
-    
+
     .PARAMETER GetSettings
         Instruct the script to get a list of current BIOS settings
 
@@ -37,14 +37,14 @@
 
 param(
     [Parameter(Mandatory=$false)][Switch]$GetSettings,
-    [Parameter(Mandatory=$false)][Switch]$SetSettings,    
+    [Parameter(Mandatory=$false)][Switch]$SetSettings,
     [Parameter(Mandatory=$false)][ValidateNotNullOrEmpty()][String]$AdminPassword,
     [ValidateScript({
         if($_ -notmatch "(\.csv)")
         {
             throw "The specified file must be a .csv file"
         }
-        return $true 
+        return $true
     })]
     [System.IO.FileInfo]$CsvPath
 )
@@ -133,7 +133,7 @@ Function Set-DellBiosSetting
             {
                 try
                 {
-                    Set-Item -Path DellSmbios:\$SettingPath\$Name -Value $Value
+                    Set-Item -Path DellSmbios:\$SettingPath\$Name -Value $Value -ErrorAction Stop
                 }
                 catch
                 {
@@ -144,18 +144,18 @@ Function Set-DellBiosSetting
             {
                 try
                 {
-                    Set-Item -Path DellSmbios:\$SettingPath\$Name -Value $Value -Password $Password
+                    Set-Item -Path DellSmbios:\$SettingPath\$Name -Value $Value -Password $Password -ErrorAction Stop
                 }
                 catch
                 {
                     $SettingSet = "Failed"
                 }
             }
-            
+
             if($SettingSet -eq "Failed")
             {
                 Write-LogEntry -Value "Failed to set ""$Name"" to ""$Value""." -Severity 3
-                $Script:FailSet++   
+                $Script:FailSet++
             }
             else
             {
@@ -189,7 +189,7 @@ Function Write-LogEntry
 	)
     # Determine log file location
     $LogFilePath = Join-Path -Path $LogsDirectory -ChildPath $FileName
-		
+
     # Construct time stamp for log entry
     if(-not(Test-Path -Path 'variable:global:TimezoneBias'))
     {
@@ -204,16 +204,16 @@ Function Write-LogEntry
         }
     }
     $Time = -join @((Get-Date -Format "HH:mm:ss.fff"), $TimezoneBias)
-		
+
     # Construct date for log entry
     $Date = (Get-Date -Format "MM-dd-yyyy")
-		
+
     # Construct context for log entry
     $Context = $([System.Security.Principal.WindowsIdentity]::GetCurrent().Name)
-		
+
     # Construct final log entry
     $LogText = "<![LOG[$($Value)]LOG]!><time=""$($Time)"" date=""$($Date)"" component=""Manage-DellBiosSettings"" context=""$($Context)"" type=""$($Severity)"" thread=""$($PID)"" file="""">"
-		
+
     # Add value to log file
     try
     {
@@ -251,7 +251,7 @@ if([System.Environment]::Is64BitOperatingSystem)
 }
 else
 {
-    $ModuleInstallPath = ${env:ProgramFiles(x86)}    
+    $ModuleInstallPath = ${env:ProgramFiles(x86)}
 }
 
 #Verify the DellBIOSProvider module is installed
@@ -303,7 +303,7 @@ else
     {
         Import-Module DellBIOSProvider -Force -ErrorAction Stop
     }
-    catch 
+    catch
     {
         Write-LogEntry -Value "Failed to import the DellBIOSProvider module" -Severity 3
         throw "Failed to import the DellBIOSProvider module"
@@ -421,7 +421,7 @@ if($GetSettings)
     }
     else
     {
-        Write-Output $SettingObject   
+        Write-Output $SettingObject
     }
 }
 
@@ -457,14 +457,14 @@ if($SetSettings)
         {
             ForEach($Setting in $Settings){
                 Set-DellBiosSetting -Name $Setting.Name -Value $Setting.Value
-            }   
+            }
         }
         else
         {
             ForEach($Setting in $Settings){
                 $Data = $Setting.Split(',')
                 Set-DellBiosSetting -Name $Data[0].Trim() -Value $Data[1].Trim()
-            }   
+            }
         }
     }
 }

--- a/Dell/Manage-DellBiosSettings.ps1
+++ b/Dell/Manage-DellBiosSettings.ps1
@@ -18,6 +18,9 @@
         #Set BIOS settings supplied in the script
         Manage-DellBiosSettings.ps1 -SetSettings -AdminPassword ExamplePassword
 
+        #Set BIOS settings supplied in the script and script will exit with a failure if 1 or more settings have failed to be set correctly
+        Manage-DellBiosSettings.ps1 -SetSettings -AdminPassword ExamplePassword -ExitWithErrorOnFailure
+
         #Set BIOS settings supplied in a CSV file
         Manage-DellBiosSettings.ps1 -SetSettings -CsvPath C:\Temp\Settings.csv -AdminPassword ExamplePassword
 
@@ -46,7 +49,8 @@ param(
         }
         return $true
     })]
-    [System.IO.FileInfo]$CsvPath
+    [System.IO.FileInfo]$CsvPath,
+    [Parameter(Mandatory=$false)][Switch]$ExitWithErrorOnFailure
 )
 
 #List of settings to be configured ============================================================================================
@@ -258,7 +262,7 @@ else
 Write-LogEntry -Value "Checking the version of the currently installed DellBIOSProvider module" -Severity 1
 try
 {
-    $LocalVersion = Get-Package DellBIOSProvider -ErrorAction Stop | Select-Object -ExpandProperty Version
+    $LocalVersion = Get-Module -ListAvailable -Name 'DellBIOSProvider' -ErrorAction Stop | Select-Object -ExpandProperty Version
 }
 catch
 {
@@ -483,3 +487,6 @@ if($SetSettings)
 }
 Write-Output "Dell BIOS settings Management completed. Check the log file for more information"
 Write-LogEntry -Value "END - Dell BIOS settings management script" -Severity 1
+If($ExitWithErrorOnFailure -and $FailSet -gt 0){
+    Write-Error "$FailSet settings failed to set" -ErrorAction Stop
+}

--- a/Dell/Manage-DellBiosSettings.ps1
+++ b/Dell/Manage-DellBiosSettings.ps1
@@ -14,6 +14,13 @@
     .PARAMETER AdminPassword
         The current BIOS password
 
+    .PARAMETER LogsDirectory
+        The path of the directory where log files will be written to
+        If in a task sequence, LogsDirectory will automatically change to _SMSTSLogPath
+
+    .PARAMETER ExitWithErrorOnFailure
+        Instruct the script to exit with a failure if the script fails to set at least 1 setting
+
     .EXAMPLE
         #Set BIOS settings supplied in the script
         Manage-DellBiosSettings.ps1 -SetSettings -AdminPassword ExamplePassword
@@ -49,7 +56,8 @@ param(
         }
         return $true
     })]
-    [System.IO.FileInfo]$CsvPath,
+    [Parameter(Mandatory=$false)][System.IO.FileInfo]$CsvPath,
+    [Parameter(Mandatory=$false)][System.IO.DirectoryInfo]$LogsDirectory = "$ENV:ProgramData\BiosScripts\Dell",
     [Parameter(Mandatory=$false)][Switch]$ExitWithErrorOnFailure
 )
 
@@ -239,11 +247,10 @@ if(Get-TaskSequenceStatus)
 }
 else
 {
-	$LogsDirectory = "$ENV:ProgramData\BiosScripts\Dell"
-	if(!(Test-Path -PathType Container $LogsDirectory))
-	{
-		New-Item -Path $LogsDirectory -ItemType "Directory" -Force | Out-Null
-	}
+    if(!(Test-Path -PathType Container $LogsDirectory))
+    {
+        New-Item -Path $LogsDirectory -ItemType "Directory" -Force | Out-Null
+    }
 }
 Write-Output "Log path set to $LogsDirectory\Manage-DellBiosSettings.log"
 Write-LogEntry -Value "START - Dell BIOS settings management script" -Severity 1

--- a/Dell/Manage-DellBiosSettings.ps1
+++ b/Dell/Manage-DellBiosSettings.ps1
@@ -73,7 +73,7 @@ param(
     })]
     [Parameter(Mandatory=$false)][System.IO.DirectoryInfo]$LogsDirectory = "$ENV:ProgramData\BiosScripts\Dell",
     [ValidateScript({
-        if ($_ -notmatch "(\.log")
+        if ($_ -notmatch "\.log")
         {
             throw "The LogFilename must end with .log"
         }

--- a/Dell/Manage-DellBiosSettings.ps1
+++ b/Dell/Manage-DellBiosSettings.ps1
@@ -21,7 +21,7 @@
     .PARAMETER LogFilename
         The name fo the log file
 
-    .PARAMETER ExitWithErrorOnFailure
+    .PARAMETER DoNotContinueOnError
         Instruct the script to exit with a failure if the script fails to set at least 1 setting
 
     .EXAMPLE
@@ -81,7 +81,7 @@ param(
     })]
     [ValidateNotNullOrEmpty()]
     [Parameter(Mandatory=$false)][System.IO.FileInfo]$LogFileName = "Manage-DellBiosSettings.log",
-    [Parameter(Mandatory=$false)][Switch]$ExitWithErrorOnFailure
+    [Parameter(Mandatory=$false)][Switch]$DoNotContinueOnError
 )
 
 #List of settings to be configured ============================================================================================
@@ -516,7 +516,12 @@ if($SetSettings)
     Write-LogEntry -Value "$NotFound settings not found" -Severity 2
 }
 Write-Output "Dell BIOS settings Management completed. Check the log file for more information"
-Write-LogEntry -Value "END - Dell BIOS settings management script" -Severity 1
-If($ExitWithErrorOnFailure -and $FailSet -gt 0){
-    Write-Error "$FailSet settings failed to set" -ErrorAction Stop
+If((-not $DoNotContinueOnError) -and $FailSet -gt 0)
+{
+    Write-LogEntry "$FailSet settings failed to set" -Severity 3
+    Write-LogEntry -Value "END - Dell BIOS settings management script" -Severity 1
+    Write-Error "Dell BIOS - $FailSet settings failed to set" -ErrorAction Stop
+}
+Else{
+    Write-LogEntry -Value "END - Dell BIOS settings management script" -Severity 1
 }


### PR DESCRIPTION
From the quick tests I've done, without "-ErrorAction Stop", the script does not detect failed attempts at setting BIOS settings.