### PR TITLE
Fix saving BIOS setting with supervisor password

### DIFF
--- a/Lenovo/Manage-LenovoBiosSettings.ps1
+++ b/Lenovo/Manage-LenovoBiosSettings.ps1
@@ -497,7 +497,7 @@ if($SetSettings -and $SuccessSet -gt 0)
         $ReturnCode = $SaveSettings.SaveBiosSettings() | Select-Object -ExpandProperty value
     }
     
-    if($ReturnCode -eq 'Success')
+    if(($null -eq $ReturnCode) -or ($ReturnCode -eq 'Success'))
     {
         Write-Output -Value "Successfully saved BIOS settings."
         Write-LogEntry -Value "Successfully saved BIOS settings." -Severity 1


### PR DESCRIPTION
Related to issue #5
The current version of the script will not save BIOS settings on Lenovo systems with a supervisor password set.
This pull request will fix that and also verify the return code of the save step to make sure the settings were saved successfully.