### PR TITLE
Fix GetSettings - Ignore nameless values & trim values.

### DIFF
--- a/HP/Manage-HPBiosSettings.ps1
+++ b/HP/Manage-HPBiosSettings.ps1
@@ -420,7 +420,7 @@ if($SetSettings)
 #Get the current settings
 if($GetSettings)
 {
-    $SettingList = $SettingList | Select-Object Name,Value | Sort-Object Name
+    $SettingList = $SettingList | Where-Object{$_.Name -ne " "} | Select-Object Name,Value | Sort-Object Name
     $SettingObject = ForEach($Setting in $SettingList){
         #Split the current values
         $SettingSplit = ($Setting.Value).Split(',')
@@ -428,9 +428,9 @@ if($GetSettings)
         $SplitCount = 0
         while($SplitCount -lt $SettingSplit.Count)
         {
-            if($SettingSplit[$SplitCount].StartsWith('*'))
+            if($SettingSplit[$SplitCount].Trim().StartsWith('*'))
             {
-                $SetValue = ($SettingSplit[$SplitCount]).Substring(1)
+                $SetValue = ($SettingSplit[$SplitCount]).Trim().Substring(1)
                 break
             }
             else

--- a/HP/Manage-HPBiosSettings.ps1
+++ b/HP/Manage-HPBiosSettings.ps1
@@ -220,7 +220,7 @@ Function Set-HPBiosSetting
     if($NULL -ne $CurrentSetting)
     {
         #Split the current values
-        $CurrentSettingSplit = $CurrentSetting.Split(',')
+        $CurrentSettingSplit = $CurrentSetting.Split(',') | ForEach-Object{$_.Trim()}
         #Find the currently set value
         $Count = 0
         while($Count -lt $CurrentSettingSplit.Count)
@@ -423,14 +423,14 @@ if($GetSettings)
     $SettingList = $SettingList | Where-Object{$_.Name -ne " "} | Select-Object Name,Value | Sort-Object Name
     $SettingObject = ForEach($Setting in $SettingList){
         #Split the current values
-        $SettingSplit = ($Setting.Value).Split(',')
+        $SettingSplit = ($Setting.Value).Split(',') | ForEach-Object{$_.Trim()}
         #Find the currently set value
         $SplitCount = 0
         while($SplitCount -lt $SettingSplit.Count)
         {
-            if($SettingSplit[$SplitCount].Trim().StartsWith('*'))
+            if($SettingSplit[$SplitCount].StartsWith('*'))
             {
-                $SetValue = ($SettingSplit[$SplitCount]).Trim().Substring(1)
+                $SetValue = ($SettingSplit[$SplitCount]).Substring(1)
                 break
             }
             else


### PR DESCRIPTION
Hello,

2 things in this pull request:
1) On some models, GetSettings would return a bunch of BIOS settings which have a name value of a space character. So I filter those out.
2) When trying to identify the setting, sometimes there is a space at the beginning of the value so it cannot identify correctly the current value so I added a Trim() to the value to remove the extra spaces.