### PR TITLE
Change validation method for Lenovo BIOS passwords

### DIFF
--- a/HP/Manage-HPBiosSettings.ps1
+++ b/HP/Manage-HPBiosSettings.ps1
@@ -225,7 +225,7 @@ Function Set-HPBiosSetting
         $Count = 0
         while($Count -lt $CurrentSettingSplit.Count)
         {
-            if($CurrentSettingSplit[$Count].StartsWith('*'))
+            if($CurrentSettingSplit[$Count].TrimStart().StartsWith('*'))
             {
                 $CurrentValue = $CurrentSettingSplit[$Count]
                 break

--- a/HP/Manage-HPBiosSettings.ps1
+++ b/HP/Manage-HPBiosSettings.ps1
@@ -428,9 +428,9 @@ if($GetSettings)
         $SplitCount = 0
         while($SplitCount -lt $SettingSplit.Count)
         {
-            if($SettingSplit[$SplitCount].StartsWith('*'))
+            if($SettingSplit[$SplitCount].TrimStart().StartsWith('*'))
             {
-                $SetValue = ($SettingSplit[$SplitCount]).Substring(1)
+                $SetValue = ($SettingSplit[$SplitCount].TrimStart()).Substring(1)
                 break
             }
             else

--- a/Lenovo/Manage-LenovoBiosSettings.ps1
+++ b/Lenovo/Manage-LenovoBiosSettings.ps1
@@ -468,6 +468,9 @@ switch($PasswordSettings.PasswordState)
 #Ensure passwords are set correctly
 if($SetSettings -or $SetDefaults)
 {
+    #get settings from the machine
+    $SettingList = $SettingList | Select-Object CurrentSetting | where {$_.CurrentSetting -and ($_.CurrentSetting -NotLike "*ShowOnly*")} | Sort-Object CurrentSetting
+
     if($SvpSet)
     {
         Write-LogEntry -Value "Ensure the supplied supervisor password is correct" -Severity 1
@@ -476,8 +479,10 @@ if($SetSettings -or $SetDefaults)
         {
             Stop-Script -ErrorMessage "The supervisor password is set, but no password was supplied. Use the SupervisorPassword parameter when a password is set"
         }
+        #create test string for the password call 
+        $testValue = $SettingList[-1].CurrentSetting + "," + $SupervisorPassword + ",ascii,us"
         #Supervisor password set correctly
-        if($PasswordSet.SetBiosPassword("pap,$SupervisorPassword,$SupervisorPassword,ascii,us").Return -eq "Success")
+        if(($Interface.SetBiosSetting($testValue)).Return -eq "Success")
 	    {
 		    Write-LogEntry -Value "The specified supervisor password matches the currently set password" -Severity 1
         }
@@ -495,8 +500,10 @@ if($SetSettings -or $SetDefaults)
         {
             Stop-Script -ErrorMessage "The system management password is set, but no password was supplied. Use the SystemManagementPassword parameter when a password is set"
         }
+        #create test string for the password call 
+        $testValue = $SettingList[-1].CurrentSetting + "," + $SystemManagementPassword + ",ascii,us"
         #System management password set correctly
-        if($PasswordSet.SetBiosPassword("smp,$SystemManagementPassword,$SystemManagementPassword,ascii,us").Return -eq "Success")
+        if(($Interface.SetBiosSetting($testValue)).Return -eq "Success")
 	    {
 		    Write-LogEntry -Value "The specified system management password matches the currently set password" -Severity 1
         }


### PR DESCRIPTION
The operation SetBiosPassword needs a reboot to be efective. After the first execution, all SetBiosPassword operations will fail even if the password is correct until the reboot.
This can create a problem if you do multiple Manage-LenovoBiosSettings operations without rebooting between them.
The method for checking if the password is correct is changed to trying to set a value with it's current value to try to avoid this situation